### PR TITLE
feat(settings): controlar animaciones y fondo

### DIFF
--- a/app/[locale]/globals.css
+++ b/app/[locale]/globals.css
@@ -1,5 +1,14 @@
 @import "tailwindcss";
 
+html.animations-disabled *,
+html.animations-disabled *::before,
+html.animations-disabled *::after {
+  animation-duration: 0.01ms !important;
+  animation-iteration-count: 1 !important;
+  scroll-behavior: auto !important;
+  transition-duration: 0.01ms !important;
+}
+
 @plugin "tailwindcss-animate";
 @custom-variant dark (&:where(.dark, .dark *));
 

--- a/app/[locale]/layout-client.tsx
+++ b/app/[locale]/layout-client.tsx
@@ -8,14 +8,11 @@ import { BlurTextProvider } from './BlurTextContext';
 import { SuccessProvider } from './SuccessContext';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 import { messages } from '@/config/text';
+import { PreferencesProvider, usePreferences } from '../components/PreferencesProvider';
 
-export function LayoutClient({
-    children,
-    locale,
-}: Readonly<{
-    children: React.ReactNode;
-    locale: string;
-}>) {
+function Experience({ children, locale }: { children: React.ReactNode; locale: string }) {
+    const { animationsEnabled } = usePreferences();
+
     const [showCounter, setShowCounter] = useState(true);
     const [fadeOut, setFadeOut] = useState(false);
     const [showBlurText, setShowBlurText] = useState(false);
@@ -26,13 +23,18 @@ export function LayoutClient({
     const t = messages[(locale as keyof typeof messages)] || messages.en;
 
     useEffect(() => {
+        if (!animationsEnabled) {
+            setShowCounter(false);
+            setShowBlurText(true);
+            return;
+        }
         if (!showCounter) {
             const timer = setTimeout(() => {
                 setShowBlurText(true);
             }, 3000); // 3 segundos
             return () => clearTimeout(timer);
         }
-    }, [showCounter]);
+    }, [animationsEnabled, showCounter]);
 
     useEffect(() => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -52,8 +54,7 @@ export function LayoutClient({
     };
 
     return (
-        <ThemeProvider>
-            <SuccessProvider>
+        <SuccessProvider>
                 <Background />
                 <BlurTextProvider showBlurText={showBlurText}>
                     <main className="relative  top-0 h-screen overflow-auto ">
@@ -119,7 +120,16 @@ export function LayoutClient({
                     )}
                 </BlurTextProvider>
                 <Counter show={showCounter} fadeOut={fadeOut} onEnd={handleCounterEnd} />
-            </SuccessProvider>
+        </SuccessProvider>
+    );
+}
+
+export function LayoutClient({ children, locale }: Readonly<{ children: React.ReactNode; locale: string }>) {
+    return (
+        <ThemeProvider>
+            <PreferencesProvider>
+                <Experience locale={locale}>{children}</Experience>
+            </PreferencesProvider>
         </ThemeProvider>
     );
 }

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -12,6 +12,7 @@ import AnimatedContent from '../components/ReactBits/AnimatedContent';
 import { useState, useEffect } from 'react';
 import BlurText from '../components/ReactBits/BlurText';
 import { useBlurText } from './BlurTextContext';
+import SettingsButton from '../components/SettingsButton';
 
 
 export default function Home() {
@@ -118,6 +119,7 @@ export default function Home() {
 
           <div className="flex items-center justify-center gap-2">
             <ThemeSwitcher />
+            <SettingsButton locale={locale} />
             <AnimatedContent
               distance={150}
               direction="vertical"

--- a/app/components/Background.tsx
+++ b/app/components/Background.tsx
@@ -3,10 +3,12 @@ import LiquidChrome from "./ReactBits/LiquidChrome";
 import { useTheme } from "./ThemeProvider";
 import { useState, useEffect, useRef, useMemo } from "react";
 import { useSuccess } from "../[locale]/SuccessContext";
+import { usePreferences } from "./PreferencesProvider";
 
 export default function Backgtound() {
     const { isDark } = useTheme();
     const { isSuccess, isError } = useSuccess();
+    const { backgroundEnabled } = usePreferences();
     const isFirstLoadRef = useRef(true);
     const resetTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -91,6 +93,10 @@ export default function Backgtound() {
             }, 5000);
         }
     }, [isError, errorColor, targetColor]);
+
+    if (!backgroundEnabled) {
+        return <div className="absolute left-0 top-0 -z-100 h-screen w-full bg-[#e9e5ff] dark:bg-[#11224e]" />;
+    }
 
     return (
         <div className="w-full  top-0 h-screen absolute  left-0 -z-100">

--- a/app/components/CardBothSides.tsx
+++ b/app/components/CardBothSides.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import { gsap } from 'gsap';
+import { usePreferences } from './PreferencesProvider';
 
 // Animation configuration
 const ANIMATION_CONFIG = {
@@ -40,10 +41,15 @@ export default function CardBothSides({ date, event, bibleReference, bcText, adT
         typeof window !== 'undefined' && ('ontouchstart' in window || navigator.maxTouchPoints > 0)
     );
     const cardRef = useRef<HTMLDivElement>(null);
+    const { animationsEnabled } = usePreferences();
 
     // Animate when card is newly placed
     useEffect(() => {
         if (isNewlyPlaced && cardRef.current) {
+            if (!animationsEnabled) {
+                onAnimationComplete?.();
+                return;
+            }
             const card = cardRef.current;
 
             // Set initial state
@@ -61,7 +67,7 @@ export default function CardBothSides({ date, event, bibleReference, bcText, adT
                 }
             });
         }
-    }, [isNewlyPlaced, onAnimationComplete]);
+    }, [animationsEnabled, isNewlyPlaced, onAnimationComplete]);
 
     // Format date with BC/AD
     const formatDate = (dateStr: string) => {

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -4,6 +4,7 @@ import { messages } from "@/config/text";
 import ThemeSwitcher from "./ThemeSwitcher";
 import AnimatedContent from "./ReactBits/AnimatedContent";
 import InfoButton from "./InfoButton";
+import SettingsButton from "./SettingsButton";
 
 
 export default function Header() {
@@ -36,6 +37,7 @@ export default function Header() {
 
             <div className="flex items-center justify-center gap-2">
                 <ThemeSwitcher />
+                <SettingsButton locale={locale} />
                 <InfoButton locale={locale} />
             </div>
         </div>

--- a/app/components/PreferencesProvider.tsx
+++ b/app/components/PreferencesProvider.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+
+interface Preferences {
+    animationsEnabled: boolean;
+    backgroundEnabled: boolean;
+}
+
+interface PreferencesContextValue extends Preferences {
+    setAnimationsEnabled: (enabled: boolean) => void;
+    setBackgroundEnabled: (enabled: boolean) => void;
+}
+
+const STORAGE_KEY = 'jw-hitster-preferences';
+const defaultPreferences: Preferences = {
+    animationsEnabled: true,
+    backgroundEnabled: true,
+};
+
+const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
+
+export function PreferencesProvider({ children }: { children: React.ReactNode }) {
+    const [preferences, setPreferences] = useState(defaultPreferences);
+
+    useEffect(() => {
+        let timeout: ReturnType<typeof setTimeout> | undefined;
+        try {
+            const stored = window.localStorage.getItem(STORAGE_KEY);
+            if (stored) {
+                const parsed = { ...defaultPreferences, ...JSON.parse(stored) };
+                timeout = setTimeout(() => setPreferences(parsed), 0);
+            }
+        } catch {
+            // Keep defaults when browser storage is unavailable or invalid.
+        }
+        return () => {
+            if (timeout) clearTimeout(timeout);
+        };
+    }, []);
+
+    useEffect(() => {
+        document.documentElement.classList.toggle('animations-disabled', !preferences.animationsEnabled);
+        try {
+            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+        } catch {
+            // The preference remains active for this session.
+        }
+    }, [preferences]);
+
+    const value = useMemo<PreferencesContextValue>(() => ({
+        ...preferences,
+        setAnimationsEnabled: (animationsEnabled) => setPreferences((current) => ({ ...current, animationsEnabled })),
+        setBackgroundEnabled: (backgroundEnabled) => setPreferences((current) => ({ ...current, backgroundEnabled })),
+    }), [preferences]);
+
+    return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+}
+
+export function usePreferences() {
+    const context = useContext(PreferencesContext);
+    if (!context) throw new Error('usePreferences must be used inside PreferencesProvider');
+    return context;
+}

--- a/app/components/ReactBits/AnimatedContent.tsx
+++ b/app/components/ReactBits/AnimatedContent.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect } from 'react';
 import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
+import { usePreferences } from '../PreferencesProvider';
 
 gsap.registerPlugin(ScrollTrigger);
 
@@ -46,10 +47,21 @@ const AnimatedContent: React.FC<AnimatedContentProps> = ({
     ...props
 }) => {
     const ref = useRef<HTMLDivElement>(null);
+    const { animationsEnabled } = usePreferences();
 
     useEffect(() => {
         const el = ref.current;
         if (!el) return;
+
+        if (!animationsEnabled) {
+            gsap.set(el, { clearProps: 'all', visibility: 'visible' });
+            onComplete?.();
+            if (disappearAfter > 0) {
+                const timeout = window.setTimeout(() => onDisappearanceComplete?.(), disappearAfter * 1000);
+                return () => window.clearTimeout(timeout);
+            }
+            return;
+        }
 
         let scrollerTarget: Element | string | null = container || document.getElementById('snap-main-container') || null;
 
@@ -123,11 +135,12 @@ const AnimatedContent: React.FC<AnimatedContentProps> = ({
         disappearDuration,
         disappearEase,
         onComplete,
-        onDisappearanceComplete
+        onDisappearanceComplete,
+        animationsEnabled
     ]);
 
     return (
-        <div ref={ref} className={`invisible ${className}`} {...props}>
+        <div ref={ref} className={`${animationsEnabled ? 'invisible' : ''} ${className}`} {...props}>
             {children}
         </div>
     );

--- a/app/components/ReactBits/Magnet.tsx
+++ b/app/components/ReactBits/Magnet.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef, ReactNode, HTMLAttributes } from 'react';
+import { usePreferences } from '../PreferencesProvider';
 
 interface MagnetProps extends HTMLAttributes<HTMLDivElement> {
   children: ReactNode;
@@ -22,12 +23,14 @@ const Magnet: React.FC<MagnetProps> = ({
   innerClassName = '',
   ...props
 }) => {
+  const { animationsEnabled } = usePreferences();
+  const isDisabled = disabled || !animationsEnabled;
   const [isActive, setIsActive] = useState<boolean>(false);
   const [position, setPosition] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
   const magnetRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (disabled) {
+    if (isDisabled) {
       return;
     }
 
@@ -56,10 +59,10 @@ const Magnet: React.FC<MagnetProps> = ({
     return () => {
       window.removeEventListener('mousemove', handleMouseMove);
     };
-  }, [padding, disabled, magnetStrength]);
+  }, [padding, isDisabled, magnetStrength]);
 
   const transitionStyle = isActive ? activeTransition : inactiveTransition;
-  const finalPosition = disabled ? { x: 0, y: 0 } : position;
+  const finalPosition = isDisabled ? { x: 0, y: 0 } : position;
 
   return (
     <div

--- a/app/components/SettingsButton.tsx
+++ b/app/components/SettingsButton.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { Settings, Sparkles, Waves, X } from 'lucide-react';
+import { useState } from 'react';
+import { messages } from '@/config/text';
+import { usePreferences } from './PreferencesProvider';
+import AnimatedContent from './ReactBits/AnimatedContent';
+
+type Locale = keyof typeof messages;
+
+export default function SettingsButton({ locale }: { locale: Locale }) {
+    const [isOpen, setIsOpen] = useState(false);
+    const { animationsEnabled, backgroundEnabled, setAnimationsEnabled, setBackgroundEnabled } = usePreferences();
+    const t = messages[locale] || messages.en;
+
+    const options = [
+        {
+            label: t.settings.animations,
+            description: t.settings.animationsDescription,
+            enabled: animationsEnabled,
+            setEnabled: setAnimationsEnabled,
+            Icon: Sparkles,
+        },
+        {
+            label: t.settings.background,
+            description: t.settings.backgroundDescription,
+            enabled: backgroundEnabled,
+            setEnabled: setBackgroundEnabled,
+            Icon: Waves,
+        },
+    ];
+
+    return (
+        <>
+            <AnimatedContent distance={150} direction="vertical" duration={0.5} delay={0.75} className="flex items-center justify-center">
+                <button
+                    type="button"
+                    onClick={() => setIsOpen(true)}
+                    aria-label={t.settings.open}
+                    className="cursor-pointer text-(--text-light) dark:text-(--text-dark) backdrop-blur-xl bg-(--text-light)/10 dark:bg-(--text-dark)/10 hover:bg-(--text-light)/40 dark:hover:bg-(--text-dark)/40 hover:scale-105 p-2 rounded-full w-9 h-9 transition-all duration-300"
+                >
+                    <Settings className="h-full w-full" aria-hidden="true" />
+                </button>
+            </AnimatedContent>
+
+            {isOpen && (
+                <div
+                    className="fixed inset-0 z-120 flex items-center justify-center p-4 backdrop-blur-xl bg-(--text-light)/10 dark:bg-(--text-dark)/10"
+                    onClick={() => setIsOpen(false)}
+                >
+                    <section
+                        role="dialog"
+                        aria-modal="true"
+                        aria-labelledby="settings-title"
+                        className="relative w-full max-w-lg rounded-3xl border border-white/10 bg-(--text-dark) p-6 text-(--text-light) shadow-2xl dark:bg-(--text-light) dark:text-(--text-dark) md:p-8"
+                        onClick={(event) => event.stopPropagation()}
+                    >
+                        <button
+                            type="button"
+                            onClick={() => setIsOpen(false)}
+                            aria-label={t.settings.close}
+                            className="absolute right-4 top-4 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full hover:bg-white/10 dark:hover:bg-black/10"
+                        >
+                            <X aria-hidden="true" />
+                        </button>
+                        <h2 id="settings-title" className="pr-12 text-3xl font-bold">{t.settings.title}</h2>
+                        <p className="mt-2 text-sm opacity-70">{t.settings.description}</p>
+
+                        <div className="mt-8 space-y-3">
+                            {options.map(({ label, description, enabled, setEnabled, Icon }) => (
+                                <div key={label} className="flex items-center gap-4 rounded-2xl bg-white/8 p-4 dark:bg-black/8">
+                                    <span className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-white/10 dark:bg-black/10">
+                                        <Icon aria-hidden="true" />
+                                    </span>
+                                    <span className="min-w-0 flex-1">
+                                        <span className="block font-semibold">{label}</span>
+                                        <span className="block text-sm opacity-65">{description}</span>
+                                    </span>
+                                    <button
+                                        type="button"
+                                        role="switch"
+                                        aria-checked={enabled}
+                                        aria-label={label}
+                                        onClick={() => setEnabled(!enabled)}
+                                        className={`relative h-8 w-14 shrink-0 cursor-pointer rounded-full border transition-colors ${enabled ? 'border-emerald-300/40 bg-emerald-500' : 'border-white/15 bg-white/15 dark:border-black/15 dark:bg-black/15'}`}
+                                    >
+                                        <span className={`absolute left-1 top-1 h-6 w-6 rounded-full bg-white shadow-md transition-transform ${enabled ? 'translate-x-6' : 'translate-x-0'}`} />
+                                    </button>
+                                </div>
+                            ))}
+                        </div>
+                    </section>
+                </div>
+            )}
+        </>
+    );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -16,6 +16,16 @@
     "placeCard": "Place this card",
     "placeHere": "Place here",
     "playAgain": "Play Again",
+    "settings": {
+        "open": "Open settings",
+        "close": "Close settings",
+        "title": "Settings",
+        "description": "Customize the visual experience. Changes are saved on this device.",
+        "animations": "Animations",
+        "animationsDescription": "Motion, entrances, and interactive effects",
+        "background": "Dynamic background",
+        "backgroundDescription": "Fluid effect that reacts to the game"
+    },
     "bc": "b.c.e.",
     "ad": "c.e.",
     "instructions": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -16,6 +16,16 @@
     "placeCard": "Coloca esta tarjeta",
     "placeHere": "Colocar aquí",
     "playAgain": "Jugar de nuevo",
+    "settings": {
+        "open": "Abrir configuración",
+        "close": "Cerrar configuración",
+        "title": "Configuración",
+        "description": "Personaliza la experiencia visual. Los cambios se guardan en este dispositivo.",
+        "animations": "Animaciones",
+        "animationsDescription": "Movimientos, entradas y efectos interactivos",
+        "background": "Fondo dinámico",
+        "backgroundDescription": "Efecto fluido que reacciona a la partida"
+    },
     "bc": "a.e.c.",
     "ad": "e.c.",
     "instructions": {


### PR DESCRIPTION
## Resumen
- añade configuración persistente y bilingüe
- permite desactivar animaciones CSS, GSAP y efectos magnéticos
- permite sustituir el fondo WebGL por un fondo estático adaptado al tema
- mantiene la configuración accesible desde inicio y juego

## Pruebas
- `npm run validate-info`
- `npm run lint` (sin errores)
- `npm run build`

Closes #23