### PR TITLE
feat(game): añadir filtros por categorías

### DIFF
--- a/app/components/GameBoard.tsx
+++ b/app/components/GameBoard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createPortal } from 'react-dom';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CardBothSides from './CardBothSides';
 import CardDataOnly from './CardDataOnly';
 import gameData from '@/config/info.json';
@@ -12,6 +12,7 @@ import { useSuccess } from '../[locale]/SuccessContext';
 import Magnet from './ReactBits/Magnet';
 import ShinyText from './ReactBits/ShinyText';
 import { useTheme } from './ThemeProvider';
+import { GameCategory, matchesGameCategory } from '@/lib/gameCategories';
 
 interface GameItem {
     date: string;
@@ -65,6 +66,7 @@ export default function GameBoard({ locale }: { locale: string }) {
     const [score, setScore] = useState(0);
     const [shuffledDeck, setShuffledDeck] = useState<BoardCard[]>([]);
     const [deckIndex, setDeckIndex] = useState(0);
+    const [selectedCategory, setSelectedCategory] = useLocalStorage<GameCategory>('jw-hitster-game-category', 'all');
 
     const [message, setMessage] = useState<ActiveMessage | null>(null);
     const [draggedOver, setDraggedOver] = useState<number | null>(null);
@@ -81,6 +83,10 @@ export default function GameBoard({ locale }: { locale: string }) {
     const lang = (locale === 'es' || locale === 'en' ? locale : 'en') as keyof typeof messages;
     const t = messages[lang];
     const MESSAGE_VISIBILITY_SECONDS = 2.5;
+    const categoryOptions = useMemo(() => (['all', 'people', 'kings', 'bibleBooks', 'worldPowers'] as GameCategory[]).map((category) => ({
+        category,
+        count: (gameData as GameItem[]).filter((item) => matchesGameCategory(item, category)).length,
+    })), []);
 
     const showMessage = useCallback((text: string, tone: MessageTone) => {
         setMessage({
@@ -151,7 +157,7 @@ export default function GameBoard({ locale }: { locale: string }) {
 
     const startGame = () => {
         // Create a shuffled deck with unique IDs
-        const deck = (gameData as GameItem[]).map((item, index) => ({
+        const deck = (gameData as GameItem[]).filter((item) => matchesGameCategory(item, selectedCategory)).map((item, index) => ({
             id: index,
             ...item,
         }));
@@ -388,6 +394,30 @@ export default function GameBoard({ locale }: { locale: string }) {
                         ))}
                     </div>
 
+                    <section aria-labelledby="category-title" className="mx-auto mt-20 max-w-4xl text-center text-(--text-light) dark:text-(--text-dark)">
+                        <h2 id="category-title" className="text-2xl font-extrabold">{t.filters.title}</h2>
+                        <p className="mt-2 opacity-70">{t.filters.description}</p>
+                        <div className="mt-6 flex flex-wrap justify-center gap-3">
+                            {categoryOptions.map(({ category, count }) => {
+                                const isSelected = selectedCategory === category;
+                                return (
+                                    <button
+                                        key={category}
+                                        type="button"
+                                        aria-pressed={isSelected}
+                                        onClick={() => setSelectedCategory(category)}
+                                        className={`cursor-pointer rounded-full border px-5 py-3 text-sm font-semibold backdrop-blur-xl transition-all duration-300 hover:-translate-y-1 ${isSelected
+                                            ? 'border-(--text-light) bg-(--text-light) text-(--text-dark) shadow-lg dark:border-(--text-dark) dark:bg-(--text-dark) dark:text-(--text-light)'
+                                            : 'border-(--text-light)/20 bg-(--text-light)/10 hover:bg-(--text-light)/25 dark:border-(--text-dark)/20 dark:bg-(--text-dark)/10 dark:hover:bg-(--text-dark)/25'
+                                            }`}
+                                    >
+                                        {t.filters[category]} <span className="ml-1 opacity-60">{count}</span>
+                                    </button>
+                                );
+                            })}
+                        </div>
+                    </section>
+
                     {/* SPACE */}
                     <div className=' h-[25vh] md:h-50 '></div>
 
@@ -397,7 +427,7 @@ export default function GameBoard({ locale }: { locale: string }) {
                         <Magnet padding={500} disabled={false} magnetStrength={9}>
                             <button
                                 onClick={startGame}
-                                aria-label={t.start}
+                                aria-label={`${t.start}: ${t.filters[selectedCategory]}`}
                                 className="group relative overflow-hidden cursor-pointer md:text-4xl text-2xl font-semibold px-8 w- py-8
                                     text-(--text-light) dark:text-(--text-dark) rounded-2xl
                                     bg-linear-to-r from-[rgba(255,255,255,0.06)] via-[rgba(255,255,255,0.03)] to-[rgba(0,0,0,0.03)]

--- a/lib/gameCategories.ts
+++ b/lib/gameCategories.ts
@@ -1,0 +1,18 @@
+export type GameCategory = 'all' | 'people' | 'kings' | 'bibleBooks' | 'worldPowers';
+
+interface CategorizedItem {
+    event: { es: string; en: string };
+}
+
+const categoryPatterns: Record<Exclude<GameCategory, 'all'>, RegExp> = {
+    people: /nacimiento|muerte|birth|death|decapitado|beheaded|resurrección|resurrection/i,
+    kings: /\brey\b|\breina\b|\breino\b|trono|ungimiento|toma el lugar|\bking\b|\bqueen\b|\bkingdom\b|throne|anointing|succeeds/i,
+    bibleBooks: /escri(?:be|tura)|completa.*(?:génesis|éxodo|levítico|números|deuteronomio|job|josué|jueces|rut|samuel|reyes|cantares|eclesiastés|proverbios|jonás|joel|amós|oseas|isaías|miqueas|sofonías|nahúm|habacuc|lamentaciones|abdías|ezequiel|jeremías|daniel|ageo|zacarías|ester|crónicas|esdras|salmos|nehemías|malaquías|mateo|tesalonicenses|gálatas|corintios|romanos|lucas|efesios|filipenses|colosenses|filemón|santiago|marcos|hebreos|hechos|timoteo|tito|pedro|judas|revelación|juan)|writes?|writing|completes? writing|bible is completed/i,
+    worldPowers: /potencia mundial|world power|imperio|empire/i,
+};
+
+export function matchesGameCategory(item: CategorizedItem, category: GameCategory) {
+    if (category === 'all') return true;
+    const searchableText = `${item.event.es} ${item.event.en}`;
+    return categoryPatterns[category].test(searchableText);
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -26,6 +26,15 @@
         "background": "Dynamic background",
         "backgroundDescription": "Fluid effect that reacts to the game"
     },
+    "filters": {
+        "title": "Choose your cards",
+        "description": "Play the full timeline or practice a specific category.",
+        "all": "All",
+        "people": "People",
+        "kings": "Kings",
+        "bibleBooks": "Bible books",
+        "worldPowers": "World powers"
+    },
     "bc": "b.c.e.",
     "ad": "c.e.",
     "instructions": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -26,6 +26,15 @@
         "background": "Fondo dinámico",
         "backgroundDescription": "Efecto fluido que reacciona a la partida"
     },
+    "filters": {
+        "title": "Elige las cartas",
+        "description": "Juega con toda la cronología o practica una categoría concreta.",
+        "all": "Todas",
+        "people": "Personajes",
+        "kings": "Reyes",
+        "bibleBooks": "Libros bíblicos",
+        "worldPowers": "Potencias"
+    },
     "bc": "a.e.c.",
     "ad": "e.c.",
     "instructions": {


### PR DESCRIPTION
## Resumen
- añade filtros bilingües para personajes, reyes, libros bíblicos y potencias
- muestra el número de cartas disponible por categoría
- conserva la selección en el dispositivo y la aplica al barajar
- mantiene el estilo translúcido y las transiciones existentes

## Pruebas
- comprobación de mazos: 180 todas, 28 personajes, 26 reyes, 69 libros y 8 potencias
- `npm run validate-info`
- `npm run lint` (sin errores)
- `npm run build`

Closes #21