### PR TITLE
feat(game): compartir resultado como imagen

### DIFF
--- a/app/components/GameBoard.tsx
+++ b/app/components/GameBoard.tsx
@@ -13,7 +13,8 @@ import Magnet from './ReactBits/Magnet';
 import ShinyText from './ReactBits/ShinyText';
 import { useTheme } from './ThemeProvider';
 import { GameCategory, matchesGameCategory } from '@/lib/gameCategories';
-import { Heart } from 'lucide-react';
+import { Heart, Share2 } from 'lucide-react';
+import { shareResultCard } from '@/lib/shareResult';
 
 interface GameItem {
     date: string;
@@ -73,6 +74,8 @@ export default function GameBoard({ locale }: { locale: string }) {
     const [selectedLives, setSelectedLives] = useLocalStorage<number>('jw-hitster-game-lives', 3);
     const [livesRemaining, setLivesRemaining] = useState(3);
     const [maxLives, setMaxLives] = useState(3);
+    const [gameEndedAt, setGameEndedAt] = useState<number | null>(null);
+    const [isSharing, setIsSharing] = useState(false);
 
     const [message, setMessage] = useState<ActiveMessage | null>(null);
     const [draggedOver, setDraggedOver] = useState<number | null>(null);
@@ -190,6 +193,7 @@ export default function GameBoard({ locale }: { locale: string }) {
         setTouchStartPos(null);
         setDragOffset({ x: 0, y: 0 });
         setFailedCard(null);
+        setGameEndedAt(null);
     };
 
     const checkPosition = (position: number) => {
@@ -223,6 +227,7 @@ export default function GameBoard({ locale }: { locale: string }) {
                 setDeckIndex(deckIndex + 1);
             } else {
                 showMessage(t.won, 'success');
+                setGameEndedAt(Date.now());
                 setGameState('gameOver');
             }
         } else {
@@ -237,8 +242,31 @@ export default function GameBoard({ locale }: { locale: string }) {
             } else {
                 showMessage(t.lose, 'error');
                 setLivesRemaining(0);
+                setGameEndedAt(Date.now());
                 setGameState('gameOver');
             }
+        }
+    };
+
+    const handleShareResult = async () => {
+        if (isSharing) return;
+        setIsSharing(true);
+        try {
+            const outcome = await shareResultCard({
+                locale: lang,
+                title: t.title,
+                resultLabel: t.share.result,
+                score,
+                scoreLabel: t.score,
+                category: t.filters[selectedCategory],
+                categoryLabel: t.share.category,
+                date: new Date(gameEndedAt ?? Date.now()),
+            });
+            if (outcome === 'downloaded') showMessage(t.share.downloaded, 'success');
+        } catch {
+            showMessage(t.share.error, 'error');
+        } finally {
+            setIsSharing(false);
         }
     };
 
@@ -581,7 +609,7 @@ export default function GameBoard({ locale }: { locale: string }) {
 
                 {/* Game Over Button */}
                 {gameState === 'gameOver' && (
-                    <div className="flex justify-center w-full">
+                    <div className="flex flex-wrap justify-center gap-3 w-full">
 
                         <button
                             onClick={startGame}
@@ -591,6 +619,15 @@ export default function GameBoard({ locale }: { locale: string }) {
                         hover:bg-(--text-light)/40 dark:hover:bg-(--text-dark)/40 transition"
                         >
                             {t.playAgain}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={handleShareResult}
+                            disabled={isSharing}
+                            className="flex cursor-pointer items-center gap-2 rounded-lg bg-(--text-light) px-8 py-3 font-semibold text-(--text-dark) shadow-lg transition hover:-translate-y-1 disabled:cursor-wait disabled:opacity-60 dark:bg-(--text-dark) dark:text-(--text-light)"
+                        >
+                            <Share2 className="h-5 w-5" aria-hidden="true" />
+                            {isSharing ? t.share.generating : t.share.button}
                         </button>
                     </div>
                 )}

--- a/lib/shareResult.ts
+++ b/lib/shareResult.ts
@@ -1,0 +1,113 @@
+interface ResultCardOptions {
+    locale: string;
+    title: string;
+    resultLabel: string;
+    score: number;
+    scoreLabel: string;
+    category: string;
+    categoryLabel: string;
+    date: Date;
+}
+
+export type ShareOutcome = 'shared' | 'downloaded' | 'cancelled';
+
+const WIDTH = 1200;
+const HEIGHT = 630;
+
+function createResultCanvas(options: ResultCardOptions) {
+    const canvas = document.createElement('canvas');
+    canvas.width = WIDTH;
+    canvas.height = HEIGHT;
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Canvas is not supported');
+
+    const gradient = context.createLinearGradient(0, 0, WIDTH, HEIGHT);
+    gradient.addColorStop(0, '#11224e');
+    gradient.addColorStop(0.55, '#293f78');
+    gradient.addColorStop(1, '#6e5aa5');
+    context.fillStyle = gradient;
+    context.fillRect(0, 0, WIDTH, HEIGHT);
+
+    context.globalAlpha = 0.12;
+    context.fillStyle = '#e9e5ff';
+    context.beginPath();
+    context.arc(1070, 80, 260, 0, Math.PI * 2);
+    context.fill();
+    context.beginPath();
+    context.arc(80, 650, 330, 0, Math.PI * 2);
+    context.fill();
+    context.globalAlpha = 1;
+
+    context.fillStyle = 'rgba(233, 229, 255, 0.1)';
+    context.strokeStyle = 'rgba(233, 229, 255, 0.22)';
+    context.lineWidth = 2;
+    context.beginPath();
+    context.roundRect(64, 56, WIDTH - 128, HEIGHT - 112, 36);
+    context.fill();
+    context.stroke();
+
+    context.fillStyle = '#e9e5ff';
+    context.font = '800 66px system-ui, sans-serif';
+    context.fillText(options.title, 112, 150);
+
+    context.fillStyle = 'rgba(233, 229, 255, 0.72)';
+    context.font = '600 28px system-ui, sans-serif';
+    context.fillText(options.resultLabel.toUpperCase(), 112, 218);
+
+    context.fillStyle = '#ffffff';
+    context.font = '900 170px system-ui, sans-serif';
+    context.fillText(String(options.score), 104, 430);
+    const scoreWidth = context.measureText(String(options.score)).width;
+    context.fillStyle = '#e9e5ff';
+    context.font = '700 38px system-ui, sans-serif';
+    context.fillText(options.scoreLabel, 124 + scoreWidth, 414);
+
+    const formattedDate = new Intl.DateTimeFormat(options.locale, {
+        day: '2-digit',
+        month: 'long',
+        year: 'numeric',
+    }).format(options.date);
+
+    context.fillStyle = 'rgba(233, 229, 255, 0.75)';
+    context.font = '500 28px system-ui, sans-serif';
+    context.fillText(`${options.categoryLabel}: ${options.category}`, 112, 514);
+    context.textAlign = 'right';
+    context.fillText(formattedDate, WIDTH - 112, 514);
+    context.textAlign = 'left';
+
+    context.fillStyle = '#e9e5ff';
+    context.font = '700 25px system-ui, sans-serif';
+    context.fillText('jw-hitster.ismola.dev', 112, 560);
+
+    return canvas;
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement) {
+    return new Promise<Blob>((resolve, reject) => {
+        canvas.toBlob((blob) => blob ? resolve(blob) : reject(new Error('Could not generate result image')), 'image/png');
+    });
+}
+
+export async function shareResultCard(options: ResultCardOptions): Promise<ShareOutcome> {
+    const blob = await canvasToBlob(createResultCanvas(options));
+    const dateStamp = options.date.toISOString().slice(0, 10);
+    const filename = `jw-hitster-${dateStamp}.png`;
+    const file = new File([blob], filename, { type: 'image/png' });
+
+    if (navigator.share && navigator.canShare?.({ files: [file] })) {
+        try {
+            await navigator.share({ title: options.title, files: [file] });
+            return 'shared';
+        } catch (error) {
+            if (error instanceof DOMException && error.name === 'AbortError') return 'cancelled';
+        }
+    }
+
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    link.click();
+    setTimeout(() => URL.revokeObjectURL(url), 0);
+    return 'downloaded';
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -42,6 +42,14 @@
         "life": "life",
         "lives": "lives"
     },
+    "share": {
+        "button": "Share result",
+        "generating": "Creating image…",
+        "result": "Game result",
+        "category": "Category",
+        "downloaded": "Image saved",
+        "error": "The image could not be created"
+    },
     "bc": "b.c.e.",
     "ad": "c.e.",
     "instructions": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -42,6 +42,14 @@
         "life": "vida",
         "lives": "vidas"
     },
+    "share": {
+        "button": "Compartir resultado",
+        "generating": "Creando imagen…",
+        "result": "Resultado de la partida",
+        "category": "Categoría",
+        "downloaded": "Imagen guardada",
+        "error": "No se pudo crear la imagen"
+    },
     "bc": "a.e.c.",
     "ad": "e.c.",
     "instructions": {


### PR DESCRIPTION
## Resumen
- genera una imagen PNG 1200×630 con puntuación, categoría y fecha
- conserva la estética de JW Hitster con gradientes y panel translúcido
- abre el menú nativo para compartir archivos en dispositivos compatibles
- descarga automáticamente el PNG cuando Web Share no admite imágenes
- incorpora estados y mensajes bilingües

## Pruebas
- `npm run validate-info`
- `npm run lint` (sin errores)
- `npm run build`

Closes #19