### PR TITLE
fix(storage): evitar desajustes de hidratación

### DIFF
--- a/app/[locale]/layout-client.tsx
+++ b/app/[locale]/layout-client.tsx
@@ -17,7 +17,7 @@ function Experience({ children, locale }: { children: React.ReactNode; locale: s
     const [fadeOut, setFadeOut] = useState(false);
     const [showBlurText, setShowBlurText] = useState(false);
     const [mounted, setMounted] = useState(false);
-    const [cookieConsent, setCookieConsent] = useLocalStorage('cookieConsent', '');
+    const [cookieConsent, setCookieConsent, isCookieConsentHydrated] = useLocalStorage('cookieConsent', '');
     const [isCookieModalOpen, setIsCookieModalOpen] = useState(false);
 
     const t = messages[(locale as keyof typeof messages)] || messages.en;
@@ -62,7 +62,7 @@ function Experience({ children, locale }: { children: React.ReactNode; locale: s
                         {children}
 
                     </main>
-                    {mounted && cookieConsent !== 'accepted' && (
+                    {mounted && isCookieConsentHydrated && cookieConsent !== 'accepted' && (
                         <div className="fixed left-1/2 -translate-x-1/2 bottom-4 z-110 w-full md:w-auto">
                             <div className="flex flex-col md:flex-row items-center justify-between gap-3 p-3 rounded-lg shadow-lg bg-(--text-light)/95 dark:bg-(--text-dark)/95 text-(--text-dark) dark:text-(--text-light)">
                                 <div className="text-sm">{t.cookies?.banner}</div>

--- a/app/components/GameBoard.tsx
+++ b/app/components/GameBoard.tsx
@@ -59,7 +59,7 @@ interface SavedGameState {
 }
 
 export default function GameBoard({ locale }: { locale: string }) {
-    const [savedGame, setSavedGame] = useLocalStorage<SavedGameState | null>('jw-hitster-game-state', null);
+    const [savedGame, setSavedGame, isSavedGameHydrated] = useLocalStorage<SavedGameState | null>('jw-hitster-game-state', null);
     const { triggerSuccess, triggerError } = useSuccess();
 
     // Track if component is mounted (client-side)
@@ -117,7 +117,7 @@ export default function GameBoard({ locale }: { locale: string }) {
 
     // Hydrate saved game state once after load
     useEffect(() => {
-        if (hasHydrated.current) return;
+        if (hasHydrated.current || !isSavedGameHydrated) return;
 
         if (savedGame?.gameState === 'playing') {
             setGameState(savedGame.gameState);
@@ -131,7 +131,7 @@ export default function GameBoard({ locale }: { locale: string }) {
         }
 
         hasHydrated.current = true;
-    }, [savedGame]);
+    }, [isSavedGameHydrated, savedGame]);
 
     // Save game state whenever it changes (only when playing and after mount)
     useEffect(() => {

--- a/app/hooks/useLocalStorage.ts
+++ b/app/hooks/useLocalStorage.ts
@@ -1,43 +1,42 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
-export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
-    // State to store our value
-    // Pass initial state function to useState so logic is only executed once
-    const [storedValue, setStoredValue] = useState<T>(() => {
-        if (typeof window === 'undefined') {
-            return initialValue;
-        }
-        try {
-            // Get from local storage by key
-            const item = window.localStorage.getItem(key);
-            // Parse stored json or if none return initialValue
-            return item ? JSON.parse(item) : initialValue;
-        } catch (error) {
-            // If error also return initialValue
-            console.error('Error reading from localStorage:', error);
-            return initialValue;
-        }
-    });
+export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void, boolean] {
+    const hasLocalUpdate = useRef(false);
+    const [storedValue, setStoredValue] = useState<T>(initialValue);
+    const [isHydrated, setIsHydrated] = useState(false);
 
-    // Return a wrapped version of useState's setter function that
-    // persists the new value to localStorage.
-    const setValue = (value: T | ((val: T) => T)) => {
-        try {
-            // Allow value to be a function so we have same API as useState
-            const valueToStore = value instanceof Function ? value(storedValue) : value;
-            // Save state
-            setStoredValue(valueToStore);
-            // Save to local storage
-            if (typeof window !== 'undefined') {
-                window.localStorage.setItem(key, JSON.stringify(valueToStore));
+    useEffect(() => {
+        const timeout = setTimeout(() => {
+            if (!hasLocalUpdate.current) {
+                try {
+                    const item = window.localStorage.getItem(key);
+                    if (item) setStoredValue(JSON.parse(item));
+                } catch (error) {
+                    console.error('Error reading from localStorage:', error);
+                }
             }
-        } catch (error) {
-            // A more advanced implementation would handle the error case
-            console.error('Error saving to localStorage:', error);
-        }
-    };
+            setIsHydrated(true);
+        }, 0);
 
-    return [storedValue, setValue];
+        return () => clearTimeout(timeout);
+    }, [key]);
+
+    const setValue = useCallback((value: T | ((val: T) => T)) => {
+        hasLocalUpdate.current = true;
+        setStoredValue((current) => {
+            const valueToStore = typeof value === 'function'
+                ? (value as (stored: T) => T)(current)
+                : value;
+            try {
+                window.localStorage.setItem(key, JSON.stringify(valueToStore));
+            } catch (error) {
+                console.error('Error saving to localStorage:', error);
+            }
+            return valueToStore;
+        });
+    }, [key]);
+
+    return [storedValue, setValue, isHydrated];
 }


### PR DESCRIPTION
## Resumen
- usa el valor por defecto en SSR y en el primer render del cliente
- restaura localStorage después de hidratar para evitar diferencias de atributos
- expone el estado de hidratación para reanudar partidas guardadas de forma segura
- evita el parpadeo del aviso de almacenamiento ya aceptado
- corrige el setter funcional para que nunca use un valor obsoleto

## Pruebas
- `npm run validate-info`
- `npm run lint` (sin errores)
- `npm run build`